### PR TITLE
Fix namespace of FakeEnsensoNode to keep compatibility with EnsensoNode

### DIFF
--- a/dr_ensenso_node/src/fake_ensenso.cpp
+++ b/dr_ensenso_node/src/fake_ensenso.cpp
@@ -84,7 +84,7 @@ private:
 	} publishers;
 
 public:
-	FakeEnsensoNode() : image_transport(*this) {
+	FakeEnsensoNode() : ros::NodeHandle("~"), image_transport(*this) {
 		camera_frame                        = dr::getParam<std::string>(handle(), "camera_frame");
 		publish_cloud                       = dr::getParam<bool>(handle(), "publish_cloud", publish_cloud, true);
 		publish_image                       = dr::getParam<bool>(handle(), "publish_image", publish_image, true);


### PR DESCRIPTION
I think `FakeEnsensoNode` is designed to keep compatibility with `EnsensoNode` for test. I found that it does not use private namespace unlike `EnsensoNode`. I fixed `FakeEnsensoNode` to use private namespace.