### PR TITLE
Add parameter to indicate front light availability.

### DIFF
--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -76,7 +76,7 @@ protected:
 		param<bool>("dump_images", dump_images, true);
 		param<bool>("registered", registered, true);
 		param<bool>("connect_monocular", connect_monocular, true);
-		param<bool>("has_frontlight", has_frontlight, true);
+		param<bool>("use_frontlight", use_frontlight, true);
 		param<bool>("synced_retrieve", synced_retrieve, false);
 
 		// get Ensenso serial
@@ -166,7 +166,7 @@ protected:
 		has_monocular = ensenso_camera->hasMonocular();
 
 		// check if camera really has front light. This will throw an error if it doesn't.
-		if (has_frontlight) ensenso_camera->setFrontLight(false);
+		if (use_frontlight) ensenso_camera->setFrontLight(false);
 
 		ROS_INFO_STREAM("Ensenso opened successfully.");
 	}
@@ -217,7 +217,7 @@ protected:
 			flex_view = ensenso_camera->flexView();
 			ensenso_camera->setFlexView(0);
 			ensenso_camera->setProjector(false);
-			if (has_frontlight) ensenso_camera->setFrontLight(true);
+			if (use_frontlight) ensenso_camera->setFrontLight(true);
 		}
 
 		cv::Mat image;
@@ -230,7 +230,7 @@ protected:
 
 		// restore settings
 		if (!has_monocular && capture) {
-			if (has_frontlight) ensenso_camera->setFrontLight(false);
+			if (use_frontlight) ensenso_camera->setFrontLight(false);
 			ensenso_camera->setProjector(true);
 			if (flex_view > 0) {
 				ensenso_camera->setFlexView(flex_view);
@@ -596,7 +596,7 @@ protected:
 	bool connect_monocular;
 
 	/// If true, the front light is available.
-	bool has_frontlight;
+	bool use_frontlight;
 
 	/// If true, retrieves the monocular camera and Ensenso simultaneously. A hardware trigger is advised to remove the projector from the uEye image.
 	bool synced_retrieve;

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -76,6 +76,7 @@ protected:
 		param<bool>("dump_images", dump_images, true);
 		param<bool>("registered", registered, true);
 		param<bool>("connect_monocular", connect_monocular, true);
+		param<bool>("has_frontlight", has_frontlight, true);
 		param<bool>("synced_retrieve", synced_retrieve, false);
 
 		// get Ensenso serial
@@ -164,6 +165,9 @@ protected:
 		// check if there is an monocular camera connected
 		has_monocular = ensenso_camera->hasMonocular();
 
+		// check if camera really has front light. This will throw an error if it doesn't.
+		if (has_frontlight) ensenso_camera->setFrontLight(false);
+
 		ROS_INFO_STREAM("Ensenso opened successfully.");
 	}
 
@@ -213,7 +217,7 @@ protected:
 			flex_view = ensenso_camera->flexView();
 			ensenso_camera->setFlexView(0);
 			ensenso_camera->setProjector(false);
-			ensenso_camera->setFrontLight(true);
+			if (has_frontlight) ensenso_camera->setFrontLight(true);
 		}
 
 		cv::Mat image;
@@ -226,7 +230,7 @@ protected:
 
 		// restore settings
 		if (!has_monocular && capture) {
-			ensenso_camera->setFrontLight(false);
+			if (has_frontlight) ensenso_camera->setFrontLight(false);
 			ensenso_camera->setProjector(true);
 			if (flex_view > 0) {
 				ensenso_camera->setFlexView(flex_view);
@@ -590,6 +594,9 @@ protected:
 
 	/// If true, tries to connect an monocular camera.
 	bool connect_monocular;
+
+	/// If true, the front light is available.
+	bool has_frontlight;
 
 	/// If true, retrieves the monocular camera and Ensenso simultaneously. A hardware trigger is advised to remove the projector from the uEye image.
 	bool synced_retrieve;


### PR DESCRIPTION
If the Ensenso in question does not have a front light, trying to access the parameter will break the system. This PR adds a parameter to be set by the user to indicate whether the Ensenso contains a frontlight. In case it is specified that a frontlight is available, which is untrue in reality, the system will throw an error. The check being made here is to check if setFrontLight actually works or not.