### PR TITLE
Camera matrix ros

### DIFF
--- a/dr_ensenso/include/dr_ensenso/opencv.hpp
+++ b/dr_ensenso/include/dr_ensenso/opencv.hpp
@@ -18,26 +18,12 @@ cv::Mat toCvMat(NxLibItem const & item, std::string const & what = "");
  */
 cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
 
-/// Convert a monocular NxLibItem containing camera matrix to a cv::Mat.
-/**
- * The camera matrix corresponds to the K parameter in OpenCV.
- * \throw NxError on failure.
- */
-cv::Mat monoCameraMatrix(NxLibItem const & item, std::string const & what = "");
-
 /// Convert a NxLibItem containing the distortion parameters to a cv::Mat.
 /**
  * The distortion parameters correspond to the D parameter in OpenCV.
  * \throw NxError on failure.
  */
 cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
-
-/// Convert a monocular NxLibItem containing the distortion parameters to a cv::Mat.
-/**
- * The distortion parameters correspond to the D parameter in OpenCV.
- * \throw NxError on failure.
- */
-cv::Mat monoDistortionParameters(NxLibItem const & item, std::string const & what = "");
 
 /// Convert a NxLibItem containing the projection matrix to a cv::Mat.
 /**

--- a/dr_ensenso/include/dr_ensenso/opencv.hpp
+++ b/dr_ensenso/include/dr_ensenso/opencv.hpp
@@ -11,12 +11,19 @@ namespace dr {
  */
 cv::Mat toCvMat(NxLibItem const & item, std::string const & what = "");
 
-/// Convert a NxLibItem containing camera matrix to a cv::Mat.
+/// Convert a stereo NxLibItem containing camera matrix to a cv::Mat.
 /**
  * The camera matrix corresponds to the K parameter in OpenCV.
  * \throw NxError on failure.
  */
 cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
+
+/// Convert a monocular NxLibItem containing camera matrix to a cv::Mat.
+/**
+ * The camera matrix corresponds to the K parameter in OpenCV.
+ * \throw NxError on failure.
+ */
+cv::Mat monoCameraMatrix(NxLibItem const & item, std::string const & what = "");
 
 /// Convert a NxLibItem containing the distortion parameters to a cv::Mat.
 /**
@@ -24,6 +31,13 @@ cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera = "Lef
  * \throw NxError on failure.
  */
 cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
+
+/// Convert a monocular NxLibItem containing the distortion parameters to a cv::Mat.
+/**
+ * The distortion parameters correspond to the D parameter in OpenCV.
+ * \throw NxError on failure.
+ */
+cv::Mat monoDistortionParameters(NxLibItem const & item, std::string const & what = "");
 
 /// Convert a NxLibItem containing the projection matrix to a cv::Mat.
 /**

--- a/dr_ensenso/include/dr_ensenso/opencv.hpp
+++ b/dr_ensenso/include/dr_ensenso/opencv.hpp
@@ -16,28 +16,27 @@ cv::Mat toCvMat(NxLibItem const & item, std::string const & what = "");
  * The camera matrix corresponds to the K parameter in OpenCV.
  * \throw NxError on failure.
  */
-cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
+cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & what = "");
 
 /// Convert a NxLibItem containing the distortion parameters to a cv::Mat.
 /**
  * The distortion parameters correspond to the D parameter in OpenCV.
  * \throw NxError on failure.
  */
-cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
+cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & what = "");
 
 /// Convert a NxLibItem containing the projection matrix to a cv::Mat.
 /**
  * The projection matrix corresponds to the P matrix in OpenCV.
  * \throw NxError on failure.
  */
-cv::Mat toProjectionMatrix(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
+cv::Mat toProjectionMatrix(NxLibItem const & item, std::string const & camera, std::string const & what = "");
 
 /// Convert a NxLibItem containing the rectification matrix to a cv::Mat.
 /**
  * The rectification matrix corresponds to the R matrix in OpenCV.
  * \throw NxError on failure.
  */
-cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & camera = "Left", std::string const & what = "");
-
+cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & what = "");
 
 }

--- a/dr_ensenso/src/opencv.cpp
+++ b/dr_ensenso/src/opencv.cpp
@@ -5,28 +5,6 @@
 
 namespace dr {
 
-cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
-	int error = 0;
-	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
-	for (std::size_t i=0; i<3; i++) {
-		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmCamera][j][i].asDouble(&error);
-			if (error) throw NxError(item, error, what);
-		}
-	}
-	return result;
-}
-
-cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & what) {
-	int error = 0;
-	cv::Mat result = cv::Mat::zeros(5, 1, CV_64F);
-	for (std::size_t i=0; i<5; i++) {
-		result.at<double>(i) = item[itmDistortion][i].asDouble(&error);
-		if (error) throw NxError(item, error, what);
-	}
-	return result;
-}
-
 cv::Mat toCvMat(NxLibItem const & item, std::string const & what) {
 	int error = 0;
 	cv::Mat result;
@@ -40,44 +18,42 @@ cv::Mat toCvMat(NxLibItem const & item, std::string const & what) {
 	return result;
 }
 
-cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	cv::Mat result;
-	try {
-		result = cameraMatrixImpl(item[itmCalibration][itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
-	} catch (NxError const & e) {
-		throw e;
+cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
+	int error = 0;
+	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
+	for (std::size_t i=0; i<3; i++) {
+		for (std::size_t j=0; j<3; j++) {
+			result.at<double>(i,j) = item[itmCamera][j][i].asDouble(&error);
+			if (error) throw NxError(item, error, what);
+		}
 	}
 	return result;
 }
 
-cv::Mat monoCameraMatrix(NxLibItem const & item, std::string const & what) {
-	cv::Mat result;
-	try {
-		result = cameraMatrixImpl(item[itmCalibration], what);
-	} catch (NxError const & e) {
-		throw e;
+cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
+	if (camera.compare("Mono") == 0) {
+		return cameraMatrixImpl(item, what);
+	} else {
+		return cameraMatrixImpl(item[itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
+	}
+}
+
+cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & what) {
+	int error = 0;
+	cv::Mat result = cv::Mat::zeros(5, 1, CV_64F);
+	for (std::size_t i=0; i<5; i++) {
+		result.at<double>(i) = item[itmDistortion][i].asDouble(&error);
+		if (error) throw NxError(item, error, what);
 	}
 	return result;
 }
 
 cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	cv::Mat result;
-	try {
-		result = distortionParametersImpl(item[itmCalibration][itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
-	} catch (NxError const & e) {
-		throw e;
+	if (camera.compare("Mono") == 0) {
+		return distortionParametersImpl(item, what);
+	} else {
+		return distortionParametersImpl(item[itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
 	}
-	return result;
-}
-
-cv::Mat monoDistortionParameters(NxLibItem const & item, std::string const & what) {
-	cv::Mat result;
-	try {
-		result = distortionParametersImpl(item[itmCalibration], what);
-	} catch (NxError const & e) {
-		throw e;
-	}
-	return result;
 }
 
 cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
@@ -85,7 +61,7 @@ cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & camera
 	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
 		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmCalibration][itmStereo][camera == "Left" ? itmLeft : itmRight][itmRotation][j][i].asDouble(&error);
+			result.at<double>(i,j) = item[itmStereo][camera == "Left" ? itmLeft : itmRight][itmRotation][j][i].asDouble(&error);
 			if (error) throw NxError(item, error, what);
 		}
 	}
@@ -97,13 +73,13 @@ cv::Mat toProjectionMatrix(NxLibItem const & item, std::string const & camera, s
 	cv::Mat result = cv::Mat::zeros(3, 4, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
 		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmCalibration][itmStereo][camera == "Left" ? itmLeft : itmRight][itmCamera][j][i].asDouble(&error);
+			result.at<double>(i,j) = item[itmStereo][camera == "Left" ? itmLeft : itmRight][itmCamera][j][i].asDouble(&error);
 			if (error) throw NxError(item, error, what);
 		}
 	}
 
 	if (camera == "Right") {
-		double B = item[itmCalibration][itmStereo][itmBaseline].asDouble() / 1000.0;
+		double B = item[itmStereo][itmBaseline].asDouble() / 1000.0;
 		double fx = result.at<double>(0,0);
 		result.at<double>(0,3) = (-fx * B);
 	}

--- a/dr_ensenso/src/opencv.cpp
+++ b/dr_ensenso/src/opencv.cpp
@@ -85,7 +85,7 @@ cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & camera
 	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
 		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmStereo][camera == "Left" ? itmLeft : itmRight][itmRotation][j][i].asDouble(&error);
+			result.at<double>(i,j) = item[itmCalibration][itmStereo][camera == "Left" ? itmLeft : itmRight][itmRotation][j][i].asDouble(&error);
 			if (error) throw NxError(item, error, what);
 		}
 	}
@@ -97,13 +97,13 @@ cv::Mat toProjectionMatrix(NxLibItem const & item, std::string const & camera, s
 	cv::Mat result = cv::Mat::zeros(3, 4, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
 		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmStereo][camera == "Left" ? itmLeft : itmRight][itmCamera][j][i].asDouble(&error);
+			result.at<double>(i,j) = item[itmCalibration][itmStereo][camera == "Left" ? itmLeft : itmRight][itmCamera][j][i].asDouble(&error);
 			if (error) throw NxError(item, error, what);
 		}
 	}
 
 	if (camera == "Right") {
-		double B = item[itmStereo][itmBaseline].asDouble() / 1000.0;
+		double B = item[itmCalibration][itmStereo][itmBaseline].asDouble() / 1000.0;
 		double fx = result.at<double>(0,0);
 		result.at<double>(0,3) = (-fx * B);
 	}

--- a/dr_ensenso/src/opencv.cpp
+++ b/dr_ensenso/src/opencv.cpp
@@ -18,7 +18,7 @@ cv::Mat toCvMat(NxLibItem const & item, std::string const & what) {
 	return result;
 }
 
-cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
+cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & what) {
 	int error = 0;
 	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
@@ -30,15 +30,7 @@ cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
 	return result;
 }
 
-cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	if (camera.compare("Mono") == 0) {
-		return cameraMatrixImpl(item, what);
-	} else {
-		return cameraMatrixImpl(item[itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
-	}
-}
-
-cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & what) {
+cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & what) {
 	int error = 0;
 	cv::Mat result = cv::Mat::zeros(5, 1, CV_64F);
 	for (std::size_t i=0; i<5; i++) {
@@ -48,20 +40,12 @@ cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & wha
 	return result;
 }
 
-cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	if (camera.compare("Mono") == 0) {
-		return distortionParametersImpl(item, what);
-	} else {
-		return distortionParametersImpl(item[itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
-	}
-}
-
-cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
+cv::Mat toRectificationMatrix(NxLibItem const & item, std::string const & what) {
 	int error = 0;
 	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
 	for (std::size_t i=0; i<3; i++) {
 		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmStereo][camera == "Left" ? itmLeft : itmRight][itmRotation][j][i].asDouble(&error);
+			result.at<double>(i,j) = item[itmRotation][j][i].asDouble(&error);
 			if (error) throw NxError(item, error, what);
 		}
 	}

--- a/dr_ensenso/src/opencv.cpp
+++ b/dr_ensenso/src/opencv.cpp
@@ -19,7 +19,7 @@ cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
 
 cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & what) {
 	int error = 0;
-	cv::Mat result = cv::Mat::zeros(8, 1, CV_64F);
+	cv::Mat result = cv::Mat::zeros(5, 1, CV_64F);
 	for (std::size_t i=0; i<5; i++) {
 		result.at<double>(i) = item[itmDistortion][i].asDouble(&error);
 		if (error) throw NxError(item, error, what);

--- a/dr_ensenso/src/opencv.cpp
+++ b/dr_ensenso/src/opencv.cpp
@@ -5,6 +5,28 @@
 
 namespace dr {
 
+cv::Mat cameraMatrixImpl(NxLibItem const & item, std::string const & what) {
+	int error = 0;
+	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
+	for (std::size_t i=0; i<3; i++) {
+		for (std::size_t j=0; j<3; j++) {
+			result.at<double>(i,j) = item[itmCamera][j][i].asDouble(&error);
+			if (error) throw NxError(item, error, what);
+		}
+	}
+	return result;
+}
+
+cv::Mat distortionParametersImpl(NxLibItem const & item, std::string const & what) {
+	int error = 0;
+	cv::Mat result = cv::Mat::zeros(8, 1, CV_64F);
+	for (std::size_t i=0; i<5; i++) {
+		result.at<double>(i) = item[itmDistortion][i].asDouble(&error);
+		if (error) throw NxError(item, error, what);
+	}
+	return result;
+}
+
 cv::Mat toCvMat(NxLibItem const & item, std::string const & what) {
 	int error = 0;
 	cv::Mat result;
@@ -19,23 +41,41 @@ cv::Mat toCvMat(NxLibItem const & item, std::string const & what) {
 }
 
 cv::Mat toCameraMatrix(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	int error = 0;
-	cv::Mat result = cv::Mat::zeros(3, 3, CV_64F);
-	for (std::size_t i=0; i<3; i++) {
-		for (std::size_t j=0; j<3; j++) {
-			result.at<double>(i,j) = item[itmMonocular][camera == "Left" ? itmLeft : itmRight][itmCamera][j][i].asDouble(&error);
-			if (error) throw NxError(item, error, what);
-		}
+	cv::Mat result;
+	try {
+		result = cameraMatrixImpl(item[itmCalibration][itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
+	} catch (NxError const & e) {
+		throw e;
+	}
+	return result;
+}
+
+cv::Mat monoCameraMatrix(NxLibItem const & item, std::string const & what) {
+	cv::Mat result;
+	try {
+		result = cameraMatrixImpl(item[itmCalibration], what);
+	} catch (NxError const & e) {
+		throw e;
 	}
 	return result;
 }
 
 cv::Mat toDistortionParameters(NxLibItem const & item, std::string const & camera, std::string const & what) {
-	int error = 0;
-	cv::Mat result = cv::Mat::zeros(8, 1, CV_64F);
-	for (std::size_t i=0; i<5; i++) {
-		result.at<double>(i) = item[itmMonocular][camera == "Left" ? itmLeft : itmRight][itmDistortion][i].asDouble(&error);
-		if (error) throw NxError(item, error, what);
+	cv::Mat result;
+	try {
+		result = distortionParametersImpl(item[itmCalibration][itmMonocular][camera == "Left" ? itmLeft : itmRight], what);
+	} catch (NxError const & e) {
+		throw e;
+	}
+	return result;
+}
+
+cv::Mat monoDistortionParameters(NxLibItem const & item, std::string const & what) {
+	cv::Mat result;
+	try {
+		result = distortionParametersImpl(item[itmCalibration], what);
+	} catch (NxError const & e) {
+		throw e;
 	}
 	return result;
 }

--- a/dr_ensenso_msgs/CMakeLists.txt
+++ b/dr_ensenso_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_service_files(FILES
 	Calibrate.srv
 	FinalizeCalibration.srv
 	GetCameraData.srv
+	GetCameraParams.srv
 	DetectCalibrationPattern.srv
 	InitializeCalibration.srv
 	SendPose.srv

--- a/dr_ensenso_msgs/srv/GetCameraParams.srv
+++ b/dr_ensenso_msgs/srv/GetCameraParams.srv
@@ -1,6 +1,6 @@
-string RIGHT = "Right"
-string LEFT  = "Left"
-string MONO  = "Mono"
+string RIGHT = Right
+string LEFT  = Left
+string MONO  = Mono
 
 uint8 CAMERA_MATRIX        = 0
 uint8 DISTORTION_MATRIX    = 1

--- a/dr_ensenso_msgs/srv/GetCameraParams.srv
+++ b/dr_ensenso_msgs/srv/GetCameraParams.srv
@@ -1,0 +1,13 @@
+string RIGHT = "Right"
+string LEFT  = "Left"
+string MONO  = "Mono"
+
+uint8 CAMERA_MATRIX        = 0
+uint8 DISTORTION_MATRIX    = 1
+uint8 RECTIFICATION_MATRIX = 2
+uint8 PROJECTION_MATRIX    = 3
+
+string camera    # Specify which camera we want the parameters of.
+uint8 type       # Specify what type of parameters we want.
+---
+float64[] params # The camera parameters.

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -489,9 +489,9 @@ protected:
 
 	bool onGetCameraParams(dr_ensenso_msgs::GetCameraParams::Request & req, dr_ensenso_msgs::GetCameraParams::Response & res) {
 		if (true
-			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::MONO)  != 0
-			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::LEFT)  != 0
-			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::RIGHT) != 0
+			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::MONO
+			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::LEFT
+			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::RIGHT
 		) {
 			ROS_ERROR_STREAM("Invalid camera type " << req.camera << " requested.");
 			return false;

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -506,26 +506,26 @@ protected:
 			case dr_ensenso_msgs::GetCameraParams::Request::CAMERA_MATRIX: {
 				mat = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
 				? monoCameraMatrix(*(ensenso_camera->nativeMonocular()))
-				: toCameraMatrix(ensenso_camera->native());
+				: toCameraMatrix(ensenso_camera->native(), req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::DISTORTION_MATRIX: {
 				mat = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
 				? monoDistortionParameters(*(ensenso_camera->nativeMonocular()))
-				: toDistortionParameters(ensenso_camera->native());
+				: toDistortionParameters(ensenso_camera->native(), req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::RECTIFICATION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {
 					ROS_ERROR_STREAM("Request for mono camera rectification matrix is unsupported!");
 					return false;
 				}
-				mat = toRectificationMatrix(ensenso_camera->native());
+				mat = toRectificationMatrix(ensenso_camera->native(), req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::PROJECTION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {
 					ROS_ERROR_STREAM("Request for mono camera projection matrix is unsupported!");
 					return false;
 				}
-				mat = toProjectionMatrix(ensenso_camera->native());
+				mat = toProjectionMatrix(ensenso_camera->native(), req.camera);
 				break;
 			} default: {
 				ROS_ERROR_STREAM("Invalid type requested!");

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -524,9 +524,9 @@ protected:
 
 	bool onGetCameraParams(dr_ensenso_msgs::GetCameraParams::Request & req, dr_ensenso_msgs::GetCameraParams::Response & res) {
 		if (true
-			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::MONO
-			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::LEFT
-			&& (req.camera) == dr_ensenso_msgs::GetCameraParams::Request::RIGHT
+			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::MONO
+			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::LEFT
+			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::RIGHT
 		) {
 			ROS_ERROR_STREAM("Invalid camera type " << req.camera << " requested.");
 			return false;

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -505,28 +505,30 @@ protected:
 		cv::Mat mat;
 		switch (req.type) {
 			case dr_ensenso_msgs::GetCameraParams::Request::CAMERA_MATRIX: {
-				mat = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
-				? monoCameraMatrix(*(ensenso_camera->nativeMonocular()))
-				: toCameraMatrix(ensenso_camera->native(), req.camera);
+				NxLibItem item = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
+				? *(ensenso_camera->nativeMonocular())
+				: ensenso_camera->native();
+				mat = toCameraMatrix(item[itmCalibration], req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::DISTORTION_MATRIX: {
-				mat = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
-				? monoDistortionParameters(*(ensenso_camera->nativeMonocular()))
-				: toDistortionParameters(ensenso_camera->native(), req.camera);
+				NxLibItem item = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
+				? *(ensenso_camera->nativeMonocular())
+				: ensenso_camera->native();
+				mat = toDistortionParameters(item[itmCalibration], req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::RECTIFICATION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {
 					ROS_ERROR_STREAM("Request for mono camera rectification matrix is unsupported!");
 					return false;
 				}
-				mat = toRectificationMatrix(ensenso_camera->native(), req.camera);
+				mat = toRectificationMatrix(ensenso_camera->native()[itmCalibration], req.camera);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::PROJECTION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {
 					ROS_ERROR_STREAM("Request for mono camera projection matrix is unsupported!");
 					return false;
 				}
-				mat = toProjectionMatrix(ensenso_camera->native(), req.camera);
+				mat = toProjectionMatrix(ensenso_camera->native()[itmCalibration], req.camera);
 				break;
 			} default: {
 				ROS_ERROR_STREAM("Invalid type requested!");

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -533,10 +533,9 @@ protected:
 			}
 		}
 
-		res.params.resize(mat.total());
 		for (int i = 0; i < mat.rows; i++) {
 			for (int j = 0; j < mat.cols; j++) {
-				res.params.at(i*mat.rows+j) = mat.at<double>(i, j);
+				res.params.push_back(mat.at<double>(i, j));
 			}
 		}
 

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -506,22 +506,22 @@ protected:
 		switch (req.type) {
 			case dr_ensenso_msgs::GetCameraParams::Request::CAMERA_MATRIX: {
 				NxLibItem item = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
-				? *(ensenso_camera->nativeMonocular())
-				: ensenso_camera->native();
-				mat = toCameraMatrix(item[itmCalibration], req.camera);
+				? (*(ensenso_camera->nativeMonocular()))[itmCalibration]
+				: ensenso_camera->native()[itmCalibration][itmMonocular][req.camera == "Left" ? itmLeft : itmRight];
+				mat = toCameraMatrix(item);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::DISTORTION_MATRIX: {
 				NxLibItem item = (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO)
-				? *(ensenso_camera->nativeMonocular())
-				: ensenso_camera->native();
-				mat = toDistortionParameters(item[itmCalibration], req.camera);
+				? (*(ensenso_camera->nativeMonocular()))[itmCalibration]
+				: ensenso_camera->native()[itmCalibration][itmMonocular][req.camera == "Left" ? itmLeft : itmRight];
+				mat = toDistortionParameters(item);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::RECTIFICATION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {
 					ROS_ERROR_STREAM("Request for mono camera rectification matrix is unsupported!");
 					return false;
 				}
-				mat = toRectificationMatrix(ensenso_camera->native()[itmCalibration], req.camera);
+				mat = toRectificationMatrix(ensenso_camera->native()[itmCalibration][itmStereo][req.camera == "Left" ? itmLeft : itmRight]);
 				break;
 			} case dr_ensenso_msgs::GetCameraParams::Request::PROJECTION_MATRIX: {
 				if (req.camera == dr_ensenso_msgs::GetCameraParams::Request::MONO) {

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -529,9 +529,9 @@ protected:
 
 	bool onGetCameraParams(dr_ensenso_msgs::GetCameraParams::Request & req, dr_ensenso_msgs::GetCameraParams::Response & res) {
 		if (true
-			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::MONO
-			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::LEFT
-			&& (req.camera) != dr_ensenso_msgs::GetCameraParams::Request::RIGHT
+			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::MONO
+			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::LEFT
+			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::RIGHT
 		) {
 			ROS_ERROR_STREAM("Invalid camera type " << req.camera << " requested.");
 			return false;

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -109,6 +109,7 @@ protected:
 		servers.set_workspace_calibration   = advertiseService("set_workspace_calibration"   , &EnsensoNode::onSetWorkspaceCalibration  , this);
 		servers.clear_workspace_calibration = advertiseService("clear_workspace_calibration" , &EnsensoNode::onClearWorkspaceCalibration, this);
 		servers.calibrate_workspace         = advertiseService("calibrate_workspace"         , &EnsensoNode::onCalibrateWorkspace       , this);
+		servers.store_workspace_calibration = advertiseService("store_workspace_calibration" , &EnsensoNode::onStoreWorkspaceCalibration, this);
 		servers.get_camera_params           = advertiseService("get_camera_params"           , &EnsensoNode::onGetCameraParams          , this);
 
 		// activate publishers

--- a/dr_ensenso_node/src/ensenso.cpp
+++ b/dr_ensenso_node/src/ensenso.cpp
@@ -488,11 +488,11 @@ protected:
 
 	bool onGetCameraParams(dr_ensenso_msgs::GetCameraParams::Request & req, dr_ensenso_msgs::GetCameraParams::Response & res) {
 		if (true
-			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::MONO
-			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::LEFT
-			&& req.camera != dr_ensenso_msgs::GetCameraParams::Request::RIGHT
+			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::MONO)  != 0
+			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::LEFT)  != 0
+			&& (req.camera).compare(dr_ensenso_msgs::GetCameraParams::Request::RIGHT) != 0
 		) {
-			ROS_ERROR_STREAM("Invalid camera type requested.");
+			ROS_ERROR_STREAM("Invalid camera type " << req.camera << " requested.");
 			return false;
 		}
 


### PR DESCRIPTION
This PR enables ROS users to retrieve the camera calibration parameters from the Ensenso.
 If a monocular camera is available, it is also possible to get those parameters. In summary, these are the contributions:

- Added functionality to retrieve monocular calibration parameters if available. Unfortunately, some code was "duplicated" to preserve backward compatibility for stereo cameras while also adding functionality for monocular cameras. Another thing is that, unfortunately, it was not possible to overload the function because their signatures would be the same. A solution would be to use templates but then existing code would break that use the current version. Please let me know your thoughts on this.

- ROS wrapper for opencv.cpp. Previously it was not possible to retrieve the parameters through dr_ensenso_node. The parameters can now be retrieved via a service call that returns the serialized matrix (row-major, from left-to-right and top-to-bottom). Perhaps there is a better datatstructure to send these matrices with?

- Some functions were expecting a different NxLib item than others, I tried to make this more consistent. The expected item as function parameter should now always be the item that holds the "Calibration" item.

- Some bugfixes on the matrix sizes