### PR TITLE
Parse whole tree instead of only itmParameters.

### DIFF
--- a/dr_ensenso/src/ensenso.cpp
+++ b/dr_ensenso/src/ensenso.cpp
@@ -42,7 +42,7 @@ std::string Ensenso::monocularSerialNumber() const {
 }
 
 bool Ensenso::loadParameters(std::string const parameters_file) {
-	return setNxJsonFromFile(ensenso_camera[itmParameters], parameters_file);
+	return setNxJsonFromFile(ensenso_camera, parameters_file);
 }
 
 bool Ensenso::loadMonocularParameters(std::string const parameters_file) {


### PR DESCRIPTION
Read full ensenso tree including Calibration data instead of only Parameters. This way, the calibration can still be loaded from json if they cannot be obtained from EEPROM.