### PR TITLE
Specify missing params in renderPointMap() explicitly.

### DIFF
--- a/dr_ensenso/src/ensenso.cpp
+++ b/dr_ensenso/src/ensenso.cpp
@@ -187,10 +187,13 @@ void Ensenso::loadRegisteredPointCloud(pcl::PointCloud<pcl::PointXYZ> & cloud, c
 	// Render point cloud.
 	{
 		NxLibCommand command(cmdRenderPointMap);
-		setNx(command.parameters()[itmNear], 1); // distance in millimeters to the camera (clip nothing?)
+		setNx(command.parameters()[itmNear], 1); // min distance in millimeters to the camera
+		setNx(command.parameters()[itmFar], 10000); // max distance in millimeters from the camera
 		setNx(command.parameters()[itmCamera], monocularSerialNumber());
+
 		// gives weird (RenderPointMap) results with OpenGL enabled, so disable
 		setNx(root[itmParameters][itmRenderPointMap][itmUseOpenGL], false);
+		setNx(root[itmParameters][itmRenderPointMap][itmPixelSize], 1);
 		executeNx(command);
 	}
 


### PR DESCRIPTION
I found that some parameters were not specified explicitly.... while this did not give any problems, I think it might give some performance improvements when enabling CUDA and/or OpenGL. (The latter was still not done here because of indeed how renderPointMap works with OpenGL).